### PR TITLE
fix(android): preserve camera preview aspect ratio

### DIFF
--- a/android/platform/android/res/layout/capture.xml
+++ b/android/platform/android/res/layout/capture.xml
@@ -18,9 +18,11 @@
              android:layout_width="fill_parent"
              android:layout_height="fill_parent">
 
-  <SurfaceView android:id="@+id/preview_view"
-               android:layout_width="fill_parent"
-               android:layout_height="fill_parent"/>
+  <com.google.zxing.client.android.PreviewSurfaceView
+      android:id="@+id/preview_view"
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:layout_gravity="center"/>
 
   <com.google.zxing.client.android.ViewfinderView
       android:id="@+id/viewfinder_view"

--- a/android/src/com/google/zxing/client/android/CaptureActivity.java
+++ b/android/src/com/google/zxing/client/android/CaptureActivity.java
@@ -37,8 +37,10 @@ import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.Paint;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -167,6 +169,16 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
 
     Window window = getWindow();
     window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+      window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+      window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+      window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
+                                                  View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
+                                                  View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION);
+      window.setStatusBarColor(Color.TRANSPARENT);
+      window.setNavigationBarColor(Color.TRANSPARENT);
+    }
     _instance = this;
     _layout = (FrameLayout) View.inflate(this, RHelper.getLayout("capture"), null);
 
@@ -174,6 +186,8 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
 
     if (Intents.Scan.overlayProxy != null) {
         View overlayView = Intents.Scan.overlayProxy.getOrCreateView().getNativeView();
+        overlayView.setLayoutParams(new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT,
+                                                                 FrameLayout.LayoutParams.MATCH_PARENT));
         _layout.addView(overlayView);
         overlayView.bringToFront();
     }

--- a/android/src/com/google/zxing/client/android/CaptureActivity.java
+++ b/android/src/com/google/zxing/client/android/CaptureActivity.java
@@ -51,7 +51,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.Surface;
 import android.view.SurfaceHolder;
-import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
@@ -310,7 +309,7 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
 
     }
 
-    SurfaceView surfaceView = (SurfaceView) findViewById(RHelper.getId("preview_view"));
+    PreviewSurfaceView surfaceView = (PreviewSurfaceView) findViewById(RHelper.getId("preview_view"));
     SurfaceHolder surfaceHolder = surfaceView.getHolder();
     if (hasSurface) {
       // The activity was paused but not stopped, so the surface still exists. Therefore
@@ -371,7 +370,7 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
     beepManager.close();
     cameraManager.closeDriver();
     if (!hasSurface) {
-      SurfaceView surfaceView = (SurfaceView) findViewById(RHelper.getId("preview_view"));
+      PreviewSurfaceView surfaceView = (PreviewSurfaceView) findViewById(RHelper.getId("preview_view"));
       SurfaceHolder surfaceHolder = surfaceView.getHolder();
       surfaceHolder.removeCallback(this);
     }
@@ -758,6 +757,11 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
     }
     try {
       cameraManager.openDriver(surfaceHolder);
+      PreviewSurfaceView surfaceView = (PreviewSurfaceView) findViewById(RHelper.getId("preview_view"));
+      android.graphics.Point previewSize = cameraManager.getPreviewSizeOnScreen();
+      if (previewSize != null) {
+        surfaceView.setPreviewSize(previewSize.x, previewSize.y);
+      }
       // Creating the handler starts the preview, which can also throw a RuntimeException.
       if (handler == null) {
         handler = new CaptureActivityHandler(this, decodeFormats, decodeHints, characterSet, cameraManager);

--- a/android/src/com/google/zxing/client/android/CaptureActivity.java
+++ b/android/src/com/google/zxing/client/android/CaptureActivity.java
@@ -56,6 +56,7 @@ import android.view.SurfaceHolder;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.view.WindowInsets;
 import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -126,6 +127,7 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
   private static final int ABOUT_ID = Menu.FIRST + 4;
 
   private FrameLayout _layout;
+  private FrameLayout _overlayContainer;
   private static CaptureActivity _instance;
 
   public boolean doKeepOpen() {
@@ -186,10 +188,25 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
 
     if (Intents.Scan.overlayProxy != null) {
         View overlayView = Intents.Scan.overlayProxy.getOrCreateView().getNativeView();
+        _overlayContainer = new FrameLayout(this);
+        _overlayContainer.setLayoutParams(new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT,
+                                                                       FrameLayout.LayoutParams.MATCH_PARENT));
+        _overlayContainer.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
+          @Override
+          public WindowInsets onApplyWindowInsets(View view, WindowInsets insets) {
+            view.setPadding(insets.getSystemWindowInsetLeft(),
+                            insets.getSystemWindowInsetTop(),
+                            insets.getSystemWindowInsetRight(),
+                            insets.getSystemWindowInsetBottom());
+            return insets;
+          }
+        });
         overlayView.setLayoutParams(new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT,
                                                                  FrameLayout.LayoutParams.MATCH_PARENT));
-        _layout.addView(overlayView);
-        overlayView.bringToFront();
+        _overlayContainer.addView(overlayView);
+        _layout.addView(_overlayContainer);
+        _overlayContainer.requestApplyInsets();
+        _overlayContainer.bringToFront();
     }
 
     hasSurface = false;
@@ -394,8 +411,10 @@ public final class CaptureActivity extends Activity implements SurfaceHolder.Cal
   @Override
   protected void onDestroy() {
     _instance = null;
-    if (Intents.Scan.overlayProxy != null) {
-        _layout.removeView(Intents.Scan.overlayProxy.getOrCreateView().getNativeView());
+    if (_overlayContainer != null) {
+        _overlayContainer.removeAllViews();
+        _layout.removeView(_overlayContainer);
+        _overlayContainer = null;
     }
 
     inactivityTimer.shutdown();

--- a/android/src/com/google/zxing/client/android/PreviewSurfaceView.java
+++ b/android/src/com/google/zxing/client/android/PreviewSurfaceView.java
@@ -1,0 +1,47 @@
+package com.google.zxing.client.android;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.SurfaceView;
+
+public class PreviewSurfaceView extends SurfaceView {
+
+  private int previewHeight;
+  private int previewWidth;
+
+  public PreviewSurfaceView(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  public void setPreviewSize(int width, int height) {
+    previewWidth = width;
+    previewHeight = height;
+    requestLayout();
+  }
+
+  @Override
+  protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+    int parentWidth = MeasureSpec.getSize(widthMeasureSpec);
+    int parentHeight = MeasureSpec.getSize(heightMeasureSpec);
+
+    if (previewWidth <= 0 || previewHeight <= 0 || parentWidth <= 0 || parentHeight <= 0) {
+      super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+      return;
+    }
+
+    float previewRatio = previewWidth / (float) previewHeight;
+    float parentRatio = parentWidth / (float) parentHeight;
+
+    int measuredWidth;
+    int measuredHeight;
+    if (parentRatio < previewRatio) {
+      measuredWidth = Math.round(parentHeight * previewRatio);
+      measuredHeight = parentHeight;
+    } else {
+      measuredWidth = parentWidth;
+      measuredHeight = Math.round(parentWidth / previewRatio);
+    }
+
+    setMeasuredDimension(measuredWidth, measuredHeight);
+  }
+}

--- a/android/src/com/google/zxing/client/android/camera/CameraManager.java
+++ b/android/src/com/google/zxing/client/android/camera/CameraManager.java
@@ -320,6 +320,10 @@ public final class CameraManager {
     return framingRectInPreview;
   }
 
+  public synchronized Point getPreviewSizeOnScreen() {
+    return configManager.getPreviewSizeOnScreen();
+  }
+
   
   /**
    * Allows third party apps to specify the camera ID, rather than determine


### PR DESCRIPTION
## Summary

This fixes the distorted Android camera preview reported in #75.

The Android scanner activity was stretching the camera preview SurfaceView to fill the screen. On devices where the selected camera preview size does not match the activity aspect ratio, that makes the image look vertically or horizontally distorted. The overlay can also look wrong because it is drawn over a preview that has already been stretched.

This PR adds a measured PreviewSurfaceView that keeps the selected camera preview aspect ratio and center-crops it inside the scanner activity. The existing viewfinder and decode-frame calculations remain in CameraManager.

## Context

This is intended to complement #357 from @m1ga. That PR updated the Android module, ZXing version, defaults, resultDuration support, and 16 KB page-size support. The distortion described in #75 can still happen because it comes from how the native preview surface is measured, not from ZXing itself or from a custom Titanium overlay.

Fixes #75.

## Verification

- Built the Android module with Titanium SDK 13.2.0.GA: `ti build -p android --build-only`
- Integrated the generated Android module into a Titanium app
- Installed and tested on a physical Android device
- Verified on-device that the camera preview and scanner overlay no longer appear distorted
