### PR TITLE
Use the SPDX identifier for the licence

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -7,7 +7,7 @@ apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: Lets you process 1D/2D barcodes.
 author: Stephen Tramer & Jeff English
-license: Apache License, Version 2.0
+license: Apache-2.0
 copyright: Copyright (c) 2010-2020 by Axway, Inc.
 
 

--- a/ios/manifest
+++ b/ios/manifest
@@ -7,7 +7,7 @@ apiversion: 2
 architectures: armv7 i386 x86_64 arm64
 description: Lets you process 1D/2D barcodes.
 author: Stephen Tramer, Jeff English, Hans Knöchel, Vijay Singh
-license: Apache License, Version 2.0
+license: Apache-2.0
 copyright: Copyright (c) 2010-Present by Axway Appcelerator.
 
 


### PR DESCRIPTION
The platform manifests spell this module's licence in a form that is not an SPDX identifier, and the spelling differs from other Titanium modules. Across the sixteen modules in the registry, Apache 2.0 currently appears six different ways:

    Apache 2.0
    Apache License Version 2.0
    Apache License, Version 2.0
    Apache
    Apache 2
    Apache Public License v2

This sets the manifest's licence line to Apache-2.0, the SPDX identifier, which is what this repository's own LICENSE file says.

The value is shown verbatim on https://titaniumsdk.com/modules — the site deliberately does not normalise it, because mapping six spellings onto one identifier in the site's code would mean the site asserting a licence the module itself does not declare. Fixing it at the source is the version that is actually true.

Part of TI-66.