### PR TITLE
TI-91: drop armv7 and i386 from the iOS manifest architectures

### DIFF
--- a/ios/manifest
+++ b/ios/manifest
@@ -4,7 +4,7 @@
 #
 version: 6.0.0
 apiversion: 2
-architectures: armv7 i386 x86_64 arm64
+architectures: arm64 x86_64
 description: Lets you process 1D/2D barcodes.
 author: Stephen Tramer, Jeff English, Hans Knöchel, Vijay Singh
 license: Apache-2.0


### PR DESCRIPTION
## What this changes

One line in `ios/manifest`:

```diff
-architectures: armv7 i386 x86_64 arm64
+architectures: arm64 x86_64
```

`armv7` and `i386` are slices Xcode has not produced for years. `arm64 x86_64` is what `ti.map`, `ti.nfc`, `ti.geofence` and `appcelerator.ble` carry, so this brings `ti.barcode` in line with the rest of the org.

## Please confirm before merging

`architectures` describes what a build produces, not what the already-published 6.0.0 artifact contains. Editing it here has no effect on the existing release; it applies to the next iOS build of this module. A maintainer with a working iOS toolchain should confirm the module still builds and that the produced slices match this line.

## This does not close TI-91

The ticket's central question is still open: **iOS 6.0.0 shipped 2020-09-22 while android is at 7.0.0 from 2025-10-25, and closing that five-year gap needs an iOS release, which this PR is not.** Whether iOS 6.0.0 still works against current SDKs is unanswered, and `minsdk: 9.2.0` is deliberately left alone — the ticket flags it as wanting a value that reflects reality, but that is a decision to make alongside a release, not a mechanical edit.

This PR only clears the manifest defect the ticket noted in passing.

https://linear.app/titanium-sdk/issue/TI-91
